### PR TITLE
Add Makefile for spdf builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: spdf_c spdf_cpp clean
+
+spdf_c: spdf.c
+	gcc spdf.c -o spdf_c -lpthread
+
+spdf_cpp: spdf.cpp
+	g++ spdf.cpp -o spdf_cpp
+
+clean:
+	rm -f spdf_c spdf_cpp


### PR DESCRIPTION
## Summary
- add Makefile with `spdf_c` and `spdf_cpp` targets
- add `clean` target

## Testing
- `make spdf_c`
- `make spdf_cpp`
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_684097724e3483288b52fdcd77ebbe2c