### PR TITLE
Fix stream allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ SPdf is a lightweight, custom implementation for managing structured streams of 
 - **Cross-Platform**: Written in C and C++ for performance and compatibility.
 - **Thread-Safe Operations**: Utilizes mutex locks for thread safety during stream manipulation.
 - **Unique Stream IDs**: Automatic generation of UUIDs for data stream identification.
+- **Buffer Duplication**: `create_stream` copies the caller's data into an internal
+  buffer, leaving ownership with the caller.
 
 ## Project Structure
 ```

--- a/spdf.c
+++ b/spdf.c
@@ -118,6 +118,10 @@ spdf_stream_t *create_default_metadata_stream() {
   return stream;
 }
 
+/*
+ * create_stream duplicates the caller provided buffer. The caller retains
+ * ownership of the original memory.
+ */
 spdf_stream_t *create_stream(void *data, size_t size) {
   spdf_stream_t *stream = (spdf_stream_t *)calloc(1, sizeof(spdf_stream_t));
   if (!stream)
@@ -127,6 +131,8 @@ spdf_stream_t *create_stream(void *data, size_t size) {
   stream->stream_type = DATA_STREAM;
   strncpy(stream->version, VERSION, VERSION_LEN);
   stream->data = (void*)calloc(size, sizeof(char));
+  if (stream->data && data)
+    memcpy(stream->data, data, size);
   stream->data_size = size;
 
   stream->updated = time(NULL);


### PR DESCRIPTION
## Summary
- copy bytes into newly allocated stream buffer
- note buffer copy behaviour in README

## Testing
- `gcc -Wall -Wextra -std=c99 -c spdf.c -lpthread`

------
https://chatgpt.com/codex/tasks/task_e_6840976dbf4083289fccc4d1fe0549bf