### PR TITLE
Remove unused hash function

### DIFF
--- a/spdf.c
+++ b/spdf.c
@@ -42,15 +42,6 @@ char *generate_id() {
   return id;
 }
 
-uint32_t hash(unsigned char *str) {
-  uint32_t h = 5381;
-  int c;
-
-  while ((c = *str++))
-    h = ((h << 5) + h) + c;
-
-  return h;
-}
 
 
 // stream.c


### PR DESCRIPTION
## Summary
- delete the unused `hash` function from `spdf.c`

## Testing
- `gcc spdf.c -o spdf_c -lpthread`
- `./spdf_c`

------
https://chatgpt.com/codex/tasks/task_e_6840976fe70c83288437b62bc5c0e226