### PR TITLE
Fix leak when removing streams

### DIFF
--- a/spdf.c
+++ b/spdf.c
@@ -272,6 +272,8 @@ bool remove_stream(spdf_stream_t *stream, spdf_t *doc) {
       continue;
 
     doc->xref_offset -= sizeof(spdf_stream_t) + stream->data_size;
+    free(doc->streams[i]->data);
+    doc->streams[i]->data_size = 0;
     memset(doc->streams[i], 0, sizeof(spdf_stream_t));
     doc->streams[i]->stream_type = METADATA_STREAM;
     strncpy(doc->streams[i]->version, VERSION, VERSION_LEN);


### PR DESCRIPTION
## Summary
- free stream buffers when removing streams
- ensure `data_size` is reset

## Testing
- `gcc spdf.c -o spdf_c -lpthread`
- `./spdf_c >/tmp/output.txt && tail -n 20 /tmp/output.txt`

------
https://chatgpt.com/codex/tasks/task_e_6840976f486483289fcf3717085d9dfe