### PR TITLE
Fix stream data serialization/deserialization

### DIFF
--- a/spdf.c
+++ b/spdf.c
@@ -163,7 +163,9 @@ bool serialize_spdf_stream_t(const spdf_stream_t *stream, FILE *out) {
 
   // Write variable-length data
   if (stream->data_size > 0 && stream->data != NULL) {
-    WRITE_AND_CHECK(stream, data, out);
+    errno = 0;
+    if (fwrite(stream->data, stream->data_size, 1, out) < 1 || errno)
+      return false;
   }
 
   return true;
@@ -182,6 +184,15 @@ bool deserialize_spdf_stream_t(spdf_stream_t *stream, FILE *in) {
   READ_AND_CHECK(stream, offset, in);
   READ_AND_CHECK(stream, reading_idx, in);
   READ_AND_CHECK(stream, data_size, in);
+
+  if (stream->data_size > 0) {
+    stream->data = calloc(stream->data_size, 1);
+    if (stream->data == NULL)
+      return false;
+    errno = 0;
+    if (fread(stream->data, stream->data_size, 1, in) < 1 || errno)
+      return false;
+  }
 
   return true;
 }


### PR DESCRIPTION
## Summary
- correctly write stream data bytes instead of pointer values
- read and allocate stream data when loading

## Testing
- `gcc spdf.c -o spdf_c -lpthread`
- `./spdf_c >/tmp/output.txt && tail -n 20 /tmp/output.txt`

------
https://chatgpt.com/codex/tasks/task_e_6840976bd37c8328914d0eda16eb76ff