### PR TITLE
Fix leaks in SPDF cleanup

### DIFF
--- a/spdf.c
+++ b/spdf.c
@@ -228,8 +228,12 @@ bool add_stream(spdf_stream_t *stream, spdf_t *doc) {
   pthread_mutex_lock(doc->lock);
   printf(" 🔒");
 
-  if (stream->stream_type == DATA_STREAM)
-    strncpy(stream->id, generate_id(), ID_LEN);
+  if (stream->stream_type == DATA_STREAM) {
+    char *tmp_id = generate_id();
+    if (tmp_id)
+      strncpy(stream->id, tmp_id, ID_LEN);
+    free(tmp_id);
+  }
 
   doc->xref_offset += sizeof(spdf_stream_t) + stream->data_size;
 
@@ -305,7 +309,10 @@ spdf_t *create_spdf(size_t max_elements) {
   pthread_mutex_init(doc->lock, NULL);
   printf(" 🔓\n");
 
-  strncpy(doc->id, generate_id(), ID_LEN);
+  char *tmp_id = generate_id();
+  if (tmp_id)
+    strncpy(doc->id, tmp_id, ID_LEN);
+  free(tmp_id);
 
   doc->streams =
       (spdf_stream_t **)calloc(max_elements + 2, sizeof(spdf_stream_t *));
@@ -324,12 +331,21 @@ spdf_t *create_spdf(size_t max_elements) {
 }
 
 bool destroy_spdf(spdf_t *doc) {
-  for (size_t i = 0; i < doc->max_streams; i++)
-    if (doc->streams[i])
+  for (size_t i = 0; i < doc->max_streams; i++) {
+    if (doc->streams[i]) {
+      if (doc->streams[i]->data)
+        free(doc->streams[i]->data);
       free(doc->streams[i]);
+    }
+  }
 
-  if (doc->lock)
+  if (doc->streams)
+    free(doc->streams);
+
+  if (doc->lock) {
     pthread_mutex_destroy(doc->lock);
+    free(doc->lock);
+  }
 
   if (doc)
     free(doc);


### PR DESCRIPTION
## Summary
- clean up generated ids in `add_stream` and `create_spdf`
- release stream buffers when destroying an SPDF
- free mutex and streams array in `destroy_spdf`

## Testing
- `gcc spdf.c -o spdf_c -lpthread`
- `./spdf_c > /tmp/out_run.txt && tail -n 5 /tmp/out_run.txt`

------
https://chatgpt.com/codex/tasks/task_e_684097affadc83288e1c8aeb50c116b4