### PR TITLE
Refactor SPDF into headers with improved error checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ SPdf is a lightweight, custom implementation for managing structured streams of 
 
 ## Project Structure
 ```
-/src
-|-- spdf.c        // Core SPDF implementation in C
-|-- spdf.cpp      // Alternative C++ implementation with OOP design
-|-- main.c        // Entry point for C-based execution
-|-- main.cpp      // Entry point for C++-based execution
+spdf.h      // C API definitions
+spdf.hpp    // C++ API definitions
+spdf.c      // C implementation
+spdf.cpp    // C++ implementation
+main.c      // C demo application
+main.cpp    // C++ demo application
 ```
 
 ## Installation
@@ -23,12 +24,12 @@ To compile the project, ensure you have `gcc` and `g++` installed.
 
 ### Compile C Version
 ```bash
-gcc spdf.c -o spdf_c -lpthread
+gcc main.c spdf.c -o spdf_c -lpthread
 ```
 
 ### Compile C++ Version
 ```bash
-g++ spdf.cpp -o spdf_cpp
+g++ main.cpp spdf.cpp -o spdf_cpp
 ```
 
 ## Usage

--- a/main.c
+++ b/main.c
@@ -1,0 +1,46 @@
+#include "spdf.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+int main(int argc, char *argv[]) {
+  srand(time(NULL));
+
+  spdf_t *doc = create_spdf(32);
+  if (!doc) {
+    fprintf(stderr, "Failed to create spdf\n");
+    return EXIT_FAILURE;
+  }
+  sleep(1);
+
+  for (size_t i = 0; i < doc->max_streams - 2; i++) {
+    if (!add_stream(create_stream((void *)i, 1), doc)) {
+      destroy_spdf(doc);
+      fprintf(stderr, "failed to add stream\n");
+      return EXIT_FAILURE;
+    }
+  }
+
+  add_stream(create_stream((void *)0xdeadbeef, 1), doc);
+  print_spdf(doc);
+
+  sleep(1);
+  for (size_t i = 2; i < doc->max_streams; i++) {
+    if (!remove_stream(doc->streams[i], doc)) {
+      destroy_spdf(doc);
+      fprintf(stderr, "failed to remove stream\n");
+      return EXIT_FAILURE;
+    }
+  }
+
+  remove_stream(create_stream((void *)0xdeadbeef, 1), doc);
+  print_spdf(doc);
+
+  if (!destroy_spdf(doc)) {
+    fprintf(stderr, "failed to destroy spdf\n");
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,18 @@
+#include "spdf.hpp"
+#include <vector>
+
+int main() {
+  SPDF document;
+
+  document.addStream(
+      "UTF-8", "text/plain", "None", {0.0, 0.0},
+      {'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd', '!'});
+
+  document.addStream("Base64", "application/octet-stream", "None", {0.0, 0.0},
+                     {'S', 'G', 'V', 's', 'b', 'G', '8', 'g', 'V', '2', '9',
+                      'y', 'b', 'G', 'Q', 'h'});
+
+  document.print();
+
+  return 0;
+}

--- a/spdf.cpp
+++ b/spdf.cpp
@@ -1,13 +1,9 @@
-#include <array>
+#include "spdf.hpp"
 #include <chrono>
 #include <ctime>
 #include <iostream>
-#include <map>
-#include <memory>
 #include <random>
 #include <sstream>
-#include <string>
-#include <vector>
 
 constexpr char SPDF_HEADER[] = "%%SPDF";
 constexpr char SPDF_VERSION[] = "0.1.0";
@@ -23,7 +19,6 @@ std::string add_timestamp() {
 }
 } // namespace stopwatch
 
-// good enough for now
 namespace uuid {
 static std::random_device rd;
 static std::mt19937 gen(rd());
@@ -37,20 +32,20 @@ std::string generate_uuid_v4() {
 
   for (i = 0; i < 8; i++)
     ss << dis(gen);
-  
+
   ss << "-";
   for (i = 0; i < 4; i++)
     ss << dis(gen);
-  
+
   ss << "-4";
   for (i = 0; i < 3; i++)
     ss << dis(gen);
-  
+
   ss << "-";
   ss << dis2(gen);
   for (i = 0; i < 3; i++)
     ss << dis(gen);
-  
+
   ss << "-";
   for (i = 0; i < 12; i++)
     ss << dis(gen);
@@ -59,189 +54,129 @@ std::string generate_uuid_v4() {
 }
 } // namespace uuid
 
-class DataStream {
-public:
-  std::string type;
-  std::string uuid;
-  std::string version;
-  std::string created;
-  std::size_t offset;
-  std::string encoding;
-  std::string format;
-  std::string compression;
-  std::size_t reading_index;
-  std::array<double, 2> position;  
-  std::vector<std::uint8_t> data;
+DataStream::DataStream(std::string enc, std::string fmt, std::string comp,
+                       std::array<double, 2> pos, std::vector<uint8_t> dat)
+    : encoding(std::move(enc)), format(std::move(fmt)),
+      compression(std::move(comp)), position(pos), data(std::move(dat)) {
+  type = "Data";
+  version = "0.1.0";
+  uuid = uuid::generate_uuid_v4();
+  created = stopwatch::add_timestamp();
+}
 
-  DataStream(std::string enc, std::string fmt, std::string comp,
-             std::array<double, 2> pos, std::vector<uint8_t> dat)
-      : encoding(std::move(enc)), format(std::move(fmt)),
-        compression(std::move(comp)), position(pos), data(std::move(dat)) {
+SPDF::SPDF() {
+  version = SPDF_VERSION;
+  uuid = uuid::generate_uuid_v4();
+  created = stopwatch::add_timestamp();
+  updated = created;
+}
 
-    type = "Data";
-    version = "0.1.0";
-    uuid = uuid::generate_uuid_v4();
-    created = stopwatch::add_timestamp();
-  }
-};
+SPDF::~SPDF() = default;
 
-class SPDF {
-public:
-  std::string uuid;
-  std::string version;
-  std::string created;
-  std::string updated;  
-  std::map<std::string, size_t> xref_table;
-  std::vector<std::unique_ptr<DataStream>> streams;
+DataStream &SPDF::find_stream_by_id(const std::string &id) {
+  for (auto &s : streams)
+    if (s->uuid == id)
+      return *s;
+  throw std::runtime_error("Stream not found");
+}
 
-  SPDF() {
-    version = SPDF_VERSION;
-    uuid = uuid::generate_uuid_v4();
-    created = stopwatch::add_timestamp();
-    updated = created;
-  };
+void SPDF::print() {
+  std::cout << std::dec << std::endl
+            << SPDF_HEADER << std::endl
+            << std::endl
+            << STREAM_HEADER << std::endl
+            << "  Type         " << "Metadata" << std::endl
+            << "  Version      " << version << std::endl
+            << "  XRef Offset  " << 0xdeadbeef << std::endl
+            << "  Data Streams " << streams.size() + 42067 << std::endl
+            << "  ID           " << 0 << std::endl
+            << "  Created      " << created
+            << "  Last Update  " << updated
+            << "  DOCID        " << uuid << std::endl;
 
-  ~SPDF() = default;
-
-  DataStream &find_stream_by_id(const std::string &id) {
-    for (auto &s : streams)
-      if (s->uuid == id)
-        return *s;
-
-    throw std::runtime_error("Stream not found");
-  }
-
-  void print() {
+  for (const auto &streamPtr : streams) {
     std::cout << std::dec << std::endl
-              << SPDF_HEADER << std::endl
-              << std::endl // 6
               << STREAM_HEADER << std::endl
-              << "  Type         "
-              << "Metadata" << std::endl                                  // 0
-              << "  Version      " << version << std::endl                // 6
-              << "  XRef Offset  " << 0xdeadbeef << std::endl             // 8
-              << "  Data Streams " << streams.size() + 42067 << std::endl // 4
-              << "  ID           " << 0 << std::endl
-              << "  Created      " << created            // 4
-              << "  Last Update  " << updated            // 4
-              << "  DOCID        " << uuid << std::endl; // 35
-                                                         // total 67
-    for (const auto &streamPtr : streams) {
-      std::cout << std::dec << std::endl
-                << STREAM_HEADER << std::endl
-                << "  Type          " << streamPtr->type << std::endl     // 1
-                << "  Version       " << streamPtr->version << std::endl  // 6
-                << "  ID            " << streamPtr->uuid << std::endl     // 35
-                << "  Created       " << streamPtr->created               // 4
-                << "  Offset        " << streamPtr->offset << std::endl   // 8
-                << "  Encoding      " << streamPtr->encoding << std::endl // 1
-                << "  Format        " << streamPtr->format << std::endl   // 1
-                << "  Compression   " << streamPtr->compression
-                << std::endl                                           // 1
-                << "  Position      " << streamPtr->position[0] << " " // 8
-                << streamPtr->position[1] << std::endl                 // 8
-                << "  Reading Index " << streamPtr->reading_index
-                << std::endl // 8
-                << "  Data Size     " << streamPtr->data.size()
-                << std::endl // 8                
-                << "  Bytes         ";
-      // total 89
-      for (int i = 0; i < 5; i++) {
-        std::cout << std::hex << static_cast<int>(streamPtr->data[i]) << " ";
-      }
+              << "  Type          " << streamPtr->type << std::endl
+              << "  Version       " << streamPtr->version << std::endl
+              << "  ID            " << streamPtr->uuid << std::endl
+              << "  Created       " << streamPtr->created
+              << "  Offset        " << streamPtr->offset << std::endl
+              << "  Encoding      " << streamPtr->encoding << std::endl
+              << "  Format        " << streamPtr->format << std::endl
+              << "  Compression   " << streamPtr->compression << std::endl
+              << "  Position      " << streamPtr->position[0] << " "
+              << streamPtr->position[1] << std::endl
+              << "  Reading Index " << streamPtr->reading_index << std::endl
+              << "  Data Size     " << streamPtr->data.size() << std::endl
+              << "  Bytes         ";
+    for (int i = 0; i < 5 && i < static_cast<int>(streamPtr->data.size()); i++)
+      std::cout << std::hex << static_cast<int>(streamPtr->data[i]) << " ";
+    if (streamPtr->data.size() > 10) {
       std::cout << std::dec << "...[" << streamPtr->data.size() - 10
                 << " bytes omitted]... ";
-
-      for (int i = 5; i > 0; i--) {
+      for (int i = 5; i > 0; i--)
         std::cout << std::hex
-                  << static_cast<int>(
-                         streamPtr->data[streamPtr->data.size() - i])
+                  << static_cast<int>(streamPtr->data[streamPtr->data.size() - i])
                   << " ";
-      }
-
-      std::cout << std::endl;
     }
-
-    std::cout << std::endl
-              << "...[42,067 data streams omitted]..." << std::endl
-              << std::endl;
-
-    std::cout << STREAM_HEADER << std::endl
-              << "  Type          "
-              << "XRef" << std::endl // 1
-              << "  Version       "
-              << "0.1.0" << std::endl // 6
-              << "  ID            " << 1 << std::endl
-              << "  Cross Reference Table" << std::endl;
-
-    for (const auto &k : xref_table) {
-      auto s = find_stream_by_id(k.first);
-      std::cout << std::dec << "    " << s.reading_index << ": " << k.first
-                << " " << s.offset << std::endl;
-    }
-    std::cout << "    ...[42,067 index values ommitted]..." << std::endl;
-
-    std::cout << "  Cross Reference Offset " << 0xdeadbeef << std::endl; // 8
-
-    std::cout << std::endl << SPDF_FOOTER << std::endl; // 5
+    std::cout << std::dec << std::endl;
   }
 
-  void addStream(const std::string &encoding, const std::string &format,
-                 const std::string &compression,
-                 const std::array<double, 2> &position,
-                 const std::vector<uint8_t> &data) {
+  std::cout << std::endl
+            << "...[42,067 data streams omitted]..." << std::endl
+            << std::endl;
 
-    _addStream(std::make_unique<DataStream>(encoding, format, compression,
-                                            position, data));
+  std::cout << STREAM_HEADER << std::endl
+            << "  Type          " << "XRef" << std::endl
+            << "  Version       " << "0.1.0" << std::endl
+            << "  ID            " << 1 << std::endl
+            << "  Cross Reference Table" << std::endl;
+
+  for (const auto &k : xref_table) {
+    auto &s = find_stream_by_id(k.first);
+    std::cout << std::dec << "    " << s.reading_index << ": " << k.first
+              << " " << s.offset << std::endl;
   }
+  std::cout << "    ...[42,067 index values ommitted]..." << std::endl;
 
-  void removeStream(const std::string &key) {
-    if (xref_table.find(key) != xref_table.end()) {
-      size_t index = xref_table[key];
-      if (index < streams.size()) {
-        streams.erase(streams.begin() + index);
-        xref_table.erase(key);
+  std::cout << "  Cross Reference Offset " << 0xdeadbeef << std::endl;
 
-        for (auto &pair : xref_table) {
-          if (pair.second > index) {
-            --pair.second;
-          }
-        }
+  std::cout << std::endl << SPDF_FOOTER << std::endl;
+}
+
+void SPDF::addStream(const std::string &encoding, const std::string &format,
+                     const std::string &compression,
+                     const std::array<double, 2> &position,
+                     const std::vector<uint8_t> &data) {
+  _addStream(std::make_unique<DataStream>(encoding, format, compression, position,
+                                          data));
+}
+
+void SPDF::removeStream(const std::string &key) {
+  if (xref_table.find(key) != xref_table.end()) {
+    size_t index = xref_table[key];
+    if (index < streams.size()) {
+      streams.erase(streams.begin() + index);
+      xref_table.erase(key);
+      for (auto &pair : xref_table) {
+        if (pair.second > index)
+          --pair.second;
       }
     }
   }
+}
 
-private:
-  std::size_t _curr_read_idx = 0;
-  void _addStream(std::unique_ptr<DataStream> stream) {
-    if (_curr_read_idx == 0)
-      stream->offset = 67;  // header
+void SPDF::_addStream(std::unique_ptr<DataStream> stream) {
+  if (_curr_read_idx == 0)
+    stream->offset = 67;
+  if (_curr_read_idx == 1)
+    stream->offset = 67 + 89 + 12;
+  if (_curr_read_idx == 2)
+    stream->offset = 67 + 89 + 12 + 89 + 16;
 
-    if (_curr_read_idx == 1)
-      stream->offset = 67+89+12;  // stream[0].offset + stream[1].metadata + stream[1].data
-
-    if (_curr_read_idx == 2)
-      stream->offset = 67+89+12+89+16;  // stream[1].offset + stream[2].metadata + stream[2].data
-
-    stream->reading_index = _curr_read_idx++;
-    updated = stopwatch::add_timestamp();
-    xref_table[stream->uuid] = stream->offset;
-    streams.push_back(std::move(stream));
-  }
-};
-
-int main() {
-  SPDF document;
-
-  document.addStream(
-      "UTF-8", "text/plain", "None", {0.0, 0.0},
-      {'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd', '!'});
-
-  document.addStream("Base64", "application/octet-stream", "None", {0.0, 0.0},
-                     {'S', 'G', 'V', 's', 'b', 'G', '8', 'g', 'V', '2', '9',
-                      'y', 'b', 'G', 'Q', 'h'});
-
-  document.print();
-
-  return 0;
+  stream->reading_index = _curr_read_idx++;
+  updated = stopwatch::add_timestamp();
+  xref_table[stream->uuid] = stream->offset;
+  streams.push_back(std::move(stream));
 }

--- a/spdf.h
+++ b/spdf.h
@@ -1,0 +1,81 @@
+#ifndef SPDF_H
+#define SPDF_H
+
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <errno.h>
+
+#define VERSION "000.000.001"
+#define VERSION_LEN 12
+#define ID_CHARS "0123456789ABCDEFGHIJKLMNOPQRSATUVWXYZ"
+#define ID_LEN 36
+
+#define WRITE_AND_CHECK(stream, member, out) \
+  do { \
+    errno = 0; \
+    if (fwrite(&(stream)->member, sizeof((stream)->member), 1, (out)) < 1 || errno) \
+      return false; \
+  } while (0)
+
+#define READ_AND_CHECK(stream, member, in) \
+  do { \
+    errno = 0; \
+    if (fread(&(stream)->member, sizeof((stream)->member), 1, (in)) < 1 || errno) \
+      return false; \
+  } while (0)
+
+enum stream_type { METADATA_STREAM = 0, XREF_STREAM, DATA_STREAM };
+enum encoding { UTF8 = 0 };
+enum mime_type { TEXT = 0, BINARY };
+enum compression { NO_COMPRESSION = 0, ZIP, TAR };
+
+typedef struct {
+  uint8_t stream_type;
+  char version[VERSION_LEN];
+  char id[ID_LEN];
+  time_t created;
+  time_t updated;
+  double position[2];
+  uint8_t encoding;
+  uint8_t mime_type;
+  uint8_t compression;
+  size_t offset;
+  size_t reading_idx;
+  size_t data_size;
+  void *data;
+} spdf_stream_t;
+
+typedef struct {
+  pthread_mutex_t *lock;
+  char version[VERSION_LEN];
+  char id[ID_LEN];
+  time_t created;
+  time_t updated;
+  size_t xref_offset;
+  size_t n_streams;
+  size_t max_streams;
+  spdf_stream_t **streams;
+} spdf_t;
+
+char *generate_id(void);
+uint32_t hash(unsigned char *str);
+void print_stream(spdf_stream_t *stream);
+spdf_stream_t *create_default_metadata_stream(void);
+spdf_stream_t *create_default_footer_stream(void);
+spdf_stream_t *create_stream(void *data, size_t size);
+bool serialize_spdf_stream_t(const spdf_stream_t *stream, FILE *out);
+bool deserialize_spdf_stream_t(spdf_stream_t *stream, FILE *in);
+spdf_t *create_spdf(size_t max_elements);
+bool destroy_spdf(spdf_t *doc);
+bool add_stream(spdf_stream_t *stream, spdf_t *doc);
+bool remove_stream(spdf_stream_t *stream, spdf_t *doc);
+bool save_spdf(const spdf_t *document, FILE *out);
+bool load_spdf(spdf_t *document, FILE *in);
+void print_spdf(spdf_t *doc);
+
+#endif // SPDF_H

--- a/spdf.hpp
+++ b/spdf.hpp
@@ -1,0 +1,62 @@
+#ifndef SPDF_HPP
+#define SPDF_HPP
+
+#include <array>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace stopwatch {
+std::string add_timestamp();
+}
+
+namespace uuid {
+std::string generate_uuid_v4();
+}
+
+class DataStream {
+public:
+  std::string type;
+  std::string uuid;
+  std::string version;
+  std::string created;
+  std::size_t offset;
+  std::string encoding;
+  std::string format;
+  std::string compression;
+  std::size_t reading_index;
+  std::array<double, 2> position;
+  std::vector<std::uint8_t> data;
+
+  DataStream(std::string enc, std::string fmt, std::string comp,
+             std::array<double, 2> pos, std::vector<uint8_t> dat);
+};
+
+class SPDF {
+public:
+  std::string uuid;
+  std::string version;
+  std::string created;
+  std::string updated;
+  std::map<std::string, size_t> xref_table;
+  std::vector<std::unique_ptr<DataStream>> streams;
+
+  SPDF();
+  ~SPDF();
+
+  DataStream &find_stream_by_id(const std::string &id);
+  void print();
+  void addStream(const std::string &encoding, const std::string &format,
+                 const std::string &compression,
+                 const std::array<double, 2> &position,
+                 const std::vector<uint8_t> &data);
+  void removeStream(const std::string &key);
+
+private:
+  std::size_t _curr_read_idx = 0;
+  void _addStream(std::unique_ptr<DataStream> stream);
+};
+
+#endif // SPDF_HPP


### PR DESCRIPTION
## Summary
- separate definitions into new `spdf.h` and `spdf.hpp`
- move C and C++ demos to `main.c` and `main.cpp`
- check allocation and mutex init return values
- update README with new build instructions

## Testing
- `gcc main.c spdf.c -o spdf_c -lpthread`
- `g++ main.cpp spdf.cpp -o spdf_cpp`
- `./spdf_c`
- `./spdf_cpp`

------
https://chatgpt.com/codex/tasks/task_e_684097735a908328a1bf0275c636ac8a