### PR TITLE
Fix memory leak in add_stream

### DIFF
--- a/spdf.c
+++ b/spdf.c
@@ -161,8 +161,14 @@ bool add_stream(spdf_stream_t *stream, spdf_t *doc) {
   if (stream->stream_type == DATA_STREAM)
     printf("+ 💧 %p", stream);
 
-  if (doc->n_streams >= doc->max_streams)
+  if (doc->n_streams >= doc->max_streams) {
+    if (stream) {
+      if (stream->data)
+        free(stream->data);
+      free(stream);
+    }
     return false;
+  }
 
   pthread_mutex_lock(doc->lock);
   printf(" 🔒");


### PR DESCRIPTION
## Summary
- free unused stream if document is already full

## Testing
- `gcc main.c spdf.c -o spdf_c -lpthread`
- `./spdf_c`

------
https://chatgpt.com/codex/tasks/task_e_6840c3082e8c83289066ad9a647aa343